### PR TITLE
Improve style/layout of shop cards a bit

### DIFF
--- a/src/WebUI/src/components/ItemProperties.vue
+++ b/src/WebUI/src/components/ItemProperties.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="is-flex is-flex-direction-column is-flex-grow-1">
     <div class="columns is-flex-wrap-wrap">
-      <div v-for="field in itemDescriptor.fields" :key="field[0]" class="column is-half is-flex is-flex-direction-column">
+      <div
+        v-for="field in itemDescriptor.fields"
+        :key="field[0]"
+        class="column is-half is-flex is-flex-direction-column"
+      >
         <span class="is-size-7">{{ field[0] }}</span>
         <strong>{{ field[1] }}</strong>
       </div>
@@ -9,7 +13,8 @@
     <b-tabs v-if="itemDescriptor.modes.length > 1" :value="weaponIdx" class="weapon-tabs">
       <b-tab-item v-for="mode in itemDescriptor.modes" :key="mode.name" :label="mode.name">
         <div v-for="field in mode.fields">
-          <strong>{{ field[1] }}</strong> {{ field[0] }}
+          <strong>{{ field[1] }}</strong>
+          {{ field[0] }}
           <br />
         </div>
         <b-taglist class="flags px-1 pt-2">
@@ -18,10 +23,15 @@
       </b-tab-item>
     </b-tabs>
     <div v-else class="is-flex is-flex-direction-column is-flex-grow-1">
-      <div v-for="mode in itemDescriptor.modes" :key="mode.name" class="is-flex is-flex-direction-column is-flex-grow-1">
+      <div
+        v-for="mode in itemDescriptor.modes"
+        :key="mode.name"
+        class="is-flex is-flex-direction-column is-flex-grow-1"
+      >
         <div class="is-flex-grow-1">
           <div v-for="field in mode.fields">
-            <strong>{{ field[1] }}</strong> {{ field[0] }}
+            <strong>{{ field[1] }}</strong>
+            {{ field[0] }}
             <br />
           </div>
         </div>

--- a/src/WebUI/src/views/Shop.vue
+++ b/src/WebUI/src/views/Shop.vue
@@ -20,11 +20,13 @@
                       :src="`${publicPath}items/${item.id}.png`"
                       alt="item image"
                       loading="lazy"
-                      style="height: 120px;"
+                      style="height: 120px"
                     />
                   </figure>
                 </div>
-                <div class="card-content content is-flex-grow-1 is-flex is-flex-direction-column px-4">
+                <div
+                  class="card-content content is-flex-grow-1 is-flex is-flex-direction-column px-4"
+                >
                   <h4 class="px-1">{{ item.name }}</h4>
                   <div class="content is-flex-grow-1 is-flex">
                     <item-properties :item="item" :rank="0" :weapon-idx="weaponIdx" />


### PR DESCRIPTION
Makes the cards in the shop look like this:
![image](https://user-images.githubusercontent.com/15195405/189507422-00a49ec6-a076-485c-ab9f-d1b67b074b7a.png)

It uses a flex layout to be a bit more consistent with positioning and spacing, and the properties are a bit easier to read, plus the tab elements are hidden if the item only has one mode (ie bows/crossbows/1h)

This updated the ItemProperties component which is also used in the Character page for displaying the User's Items, and as such it helps make https://github.com/verdie-g/crpg/pull/256 look even better:
![image](https://user-images.githubusercontent.com/15195405/190867168-cff986db-8316-4f63-abb0-dfa3430032dc.png)
![image](https://user-images.githubusercontent.com/15195405/190867138-b0f4b09a-5f2f-4b4c-b54a-3ae92de2d47a.png)
