### PR TITLE
Use flex for consistent layout of page and footer

### DIFF
--- a/src/WebUI/src/App.vue
+++ b/src/WebUI/src/App.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <nav v-if="user">
+  <div class="is-flex-grow-1 is-flex is-flex-direction-column">
+    <nav v-if="user" class="is-flex-grow-0">
       <b-navbar fixed-top :close-on-click="false">
         <template slot="brand">
           <b-navbar-item tag="router-link" :to="{ path: '/' }">cRPG</b-navbar-item>
@@ -56,11 +56,11 @@
       </b-navbar>
     </nav>
 
-    <main>
+    <main class="is-flex-grow-1">
       <router-view />
     </main>
     <!-- Display or not the footer depending on the current page -->
-    <footer v-if="$route.meta.footer === true || $route.meta.footer === undefined" class="footer">
+    <footer v-if="$route.meta.footer === true || $route.meta.footer === undefined" class="footer is-flex-grow-0">
       <div class="level">
         <div class="level-item">
           <a href="https://www.patreon.com/crpg" target="_blank" title="Donate on Patreon">

--- a/src/WebUI/src/assets/scss/index.scss
+++ b/src/WebUI/src/assets/scss/index.scss
@@ -1,0 +1,11 @@
+@import './bulma';
+
+html,
+body {
+    min-height: 100vh;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+}

--- a/src/WebUI/src/main.ts
+++ b/src/WebUI/src/main.ts
@@ -8,7 +8,7 @@ import 'buefy/dist/buefy.css';
 import '@fortawesome/fontawesome-free/css/all.css';
 import '@fortawesome/fontawesome-free/css/fontawesome.css';
 import 'leaflet/dist/leaflet.css';
-import '@/assets/scss/bulma.scss';
+import '@/assets/scss/index.scss';
 
 Vue.use(Buefy, {
   defaultIconPack: 'fas',


### PR DESCRIPTION
Not certain if this is the best way of doing this but this uses Buefy's flex helpers to layout the root elements of the app nicely so the footer is always aligned to the bottom of the page, never floating above the bottom in the case of shorter pages (eg Manage Clan).

For longer pages it just continues working as is, the page will just expand downwards and the footer will sit at the bottom of the content.
![image](https://user-images.githubusercontent.com/15195405/189534658-4b405887-fed1-4e2d-adb2-e77f423a655c.png)
