### PR TITLE
407-experience-bar-progression-not-displayed-properly-hotfix

### DIFF
--- a/src/WebUI/src/components/CharacterStatsComponent.vue
+++ b/src/WebUI/src/components/CharacterStatsComponent.vue
@@ -42,7 +42,7 @@
           class="experience-progress-bar"
           type="is-info"
           size="is-medium"
-          :max="nextLevelExperience"
+          :max="relativeCurrentNextLevelExperience"
           :value="relativeCurrentLevelExperience"
           show-value
           format="raw"
@@ -618,6 +618,10 @@ export default class CharacterCharacteristicsComponent extends Vue {
 
   get relativeCurrentLevelExperience(): number {
     return this.character.experience - getExperienceForLevel(this.character.level);
+  }
+
+  get relativeCurrentNextLevelExperience(): number {
+    return getExperienceForLevel(this.character.level + 1) - getExperienceForLevel(this.character.level);
   }
 
   get nextLevelExperience(): number {


### PR DESCRIPTION
now correct

![image](https://user-images.githubusercontent.com/33551334/193466596-4ba85b50-3813-4086-a85a-2e1396e3643b.png)

![image](https://user-images.githubusercontent.com/33551334/193466608-5eeea2f6-1d68-4d83-bb59-f5619af711ea.png)
