### PR TITLE
fix for blow hitting you before the animation collide with you

### DIFF
--- a/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
+++ b/src/Module.Server/Common/Models/CrpgAgentStatCalculateModel.cs
@@ -73,6 +73,10 @@ internal class CrpgAgentStatCalculateModel : AgentStatCalculateModel
         {
             return 15;
         }
+        else if (skill == DefaultSkills.OneHanded || skill == DefaultSkills.TwoHanded || skill == DefaultSkills.Polearm)
+        {
+            return 135;
+        }
 
         return base.GetEffectiveSkill(agentCharacter, agentOrigin, agentFormation, skill);
     }


### PR DESCRIPTION
Tested with lahire . Other peers are not aware of your item skill. This may lead to hits hitting you before the animation hits you. Setting item skill to 135 seems to help