### PR TITLE
blunt factor for cut 0.4f -> 0.35f

### DIFF
--- a/src/Module.Server/Common/Models/CrpgStrikeMagnitudeModel.cs
+++ b/src/Module.Server/Common/Models/CrpgStrikeMagnitudeModel.cs
@@ -26,7 +26,7 @@ internal class CrpgStrikeMagnitudeModel : MultiplayerStrikeMagnitudeModel
                 result = 1f; // Native 1f
                 break;
             case DamageTypes.Cut:
-                result = 0.4f; // Native .1f
+                result = 0.35f; // Native .1f
                 break;
             case DamageTypes.Pierce:
                 result = .45f; // Native .25f


### PR DESCRIPTION
Cut deals too much blunt damage. The difference between Cut and Pierce has been reduced in the earlier stage of the game. This made armor lest effective.