### PR TITLE
mod: increase rating weight

### DIFF
--- a/src/Module.Server/Common/CrpgTeamSelectComponent.cs
+++ b/src/Module.Server/Common/CrpgTeamSelectComponent.cs
@@ -342,7 +342,8 @@ internal class CrpgTeamSelectComponent : MultiplayerTeamSelectComponent
     {
         var rating = user.Character.Rating;
         float regionPenalty = CrpgRatingHelper.ComputeRegionRatingPenalty(user.Region);
-        return 0.0025f * (float)Math.Pow(rating.Value - 2 * rating.Deviation, 1.5f) * regionPenalty;
+        // https://www.desmos.com/calculator/23qchzvrw3
+        return 0.0001f * (float)Math.Pow(rating.Value - 2 * rating.Deviation, 2f) * regionPenalty;
     }
 
     private float ComputeEquippedItemsPrice(IList<CrpgEquippedItem> equippedItems)


### PR DESCRIPTION
I observed that a bunch of players usually carry the games so let's increase their weight. The difference between a 1000 and a 1800 increases from 2.4 to 3.24.

Hopefully that's the last blind change we make.
![image](https://user-images.githubusercontent.com/9092290/224559905-551a6c54-f919-4e56-968d-2c002073db79.png)
