### PR TITLE
mod: reset rating on respec/retire

### DIFF
--- a/src/Application/Characters/Commands/RespecializeCharacterCommand.cs
+++ b/src/Application/Characters/Commands/RespecializeCharacterCommand.cs
@@ -76,6 +76,7 @@ public record RespecializeCharacterCommand : IMediatorRequest<CharacterViewModel
             }
 
             _characterService.ResetCharacterCharacteristics(character, true);
+            _characterService.ResetRating(character);
 
             _db.ActivityLogs.Add(_activityLogService.CreateCharacterRespecializedLog(character.UserId, character.Id, price));
 

--- a/src/Application/Characters/Commands/RetireCharacterCommand.cs
+++ b/src/Application/Characters/Commands/RetireCharacterCommand.cs
@@ -44,6 +44,7 @@ public record RetireCharacterCommand : IMediatorRequest<CharacterViewModel>
                 return new(CommonErrors.CharacterNotFound(req.CharacterId, req.UserId));
             }
 
+            _characterService.ResetRating(character);
             var error = _characterService.Retire(character);
             if (error != null)
             {

--- a/src/Application/Common/Services/ICharacterService.cs
+++ b/src/Application/Common/Services/ICharacterService.cs
@@ -19,6 +19,8 @@ internal interface ICharacterService
     /// <param name="respecialization">If the stats points should be redistributed.</param>
     void ResetCharacterCharacteristics(Character character, bool respecialization = false);
 
+    void ResetRating(Character character);
+
     Error? Retire(Character character);
 
     void GiveExperience(Character character, int experience, bool useExperienceMultiplier);
@@ -42,16 +44,13 @@ internal class CharacterService : ICharacterService
         character.Level = _constants.MinimumLevel;
         character.Experience = _experienceTable.GetExperienceForLevel(character.Level);
         character.ForTournament = false;
-        character.Rating = new CharacterRating
-        {
-            Value = _constants.DefaultRating,
-            Deviation = _constants.DefaultRatingDeviation,
-            Volatility = _constants.DefaultRatingVolatility,
-        };
+
+        ResetCharacterCharacteristics(character);
+        ResetRating(character);
     }
 
     /// <inheritdoc />
-    public void ResetCharacterCharacteristics(Character character, bool respecialization)
+    public void ResetCharacterCharacteristics(Character character, bool respecialization = false)
     {
         character.Characteristics = new CharacterCharacteristics
         {
@@ -71,6 +70,16 @@ internal class CharacterService : ICharacterService
             },
         };
         character.Class = CharacterClass.Peasant;
+    }
+
+    public void ResetRating(Character character)
+    {
+        character.Rating = new CharacterRating
+        {
+            Value = _constants.DefaultRating,
+            Deviation = _constants.DefaultRatingDeviation,
+            Volatility = _constants.DefaultRatingVolatility,
+        };
     }
 
     public Error? Retire(Character character)

--- a/src/Application/Games/Commands/GetGameUserCommand.cs
+++ b/src/Application/Games/Commands/GetGameUserCommand.cs
@@ -233,7 +233,6 @@ public record GetGameUserCommand : IMediatorRequest<GameUserViewModel>
             };
 
             _characterService.SetDefaultValuesForCharacter(character);
-            _characterService.ResetCharacterCharacteristics(character);
             return character;
         }
 

--- a/test/Application.UTest/Characters/RespecializeCharacterCommandTest.cs
+++ b/test/Application.UTest/Characters/RespecializeCharacterCommandTest.cs
@@ -102,6 +102,7 @@ public class RespecializeCharacterCommandTest : TestBase
         Assert.That(character.Statistics.Assists, Is.EqualTo(3));
         Assert.That(character.Statistics.PlayTime, Is.EqualTo(TimeSpan.FromSeconds(4)));
         characterServiceMock.Verify(cs => cs.ResetCharacterCharacteristics(It.IsAny<Character>(), true));
+        characterServiceMock.Verify(cs => cs.ResetRating(It.IsAny<Character>()));
     }
 
     [Test]
@@ -158,6 +159,7 @@ public class RespecializeCharacterCommandTest : TestBase
         Assert.That(character.Statistics.Assists, Is.EqualTo(3));
         Assert.That(character.Statistics.PlayTime, Is.EqualTo(TimeSpan.FromSeconds(4)));
         characterServiceMock.Verify(cs => cs.ResetCharacterCharacteristics(It.IsAny<Character>(), true));
+        characterServiceMock.Verify(cs => cs.ResetRating(It.IsAny<Character>()));
     }
 
     [Test]

--- a/test/Application.UTest/Characters/RetireCharacterCommandTest.cs
+++ b/test/Application.UTest/Characters/RetireCharacterCommandTest.cs
@@ -31,6 +31,7 @@ public class RetireCharacterCommandTest : TestBase
             UserId = character.UserId,
         }, CancellationToken.None);
 
+        characterServiceMock.Verify(cs => cs.ResetRating(It.IsAny<Character>()));
         characterServiceMock.Verify(cs => cs.Retire(It.IsAny<Character>()));
     }
 

--- a/test/Application.UTest/Common/Services/CharacterServiceTest.cs
+++ b/test/Application.UTest/Common/Services/CharacterServiceTest.cs
@@ -26,6 +26,9 @@ public class CharacterServiceTest
         DefaultStrength = 3,
         DefaultAgility = 3,
         DefaultGeneration = 1,
+        DefaultRating = 101,
+        DefaultRatingDeviation = 102,
+        DefaultRatingVolatility = 103,
     };
 
     private static readonly ExperienceTable ExperienceTable = new(Constants);
@@ -177,6 +180,27 @@ public class CharacterServiceTest
         Assert.That(character.Characteristics.WeaponProficiencies.Bow, Is.Zero);
         Assert.That(character.Characteristics.WeaponProficiencies.Throwing, Is.Zero);
         Assert.That(character.Characteristics.WeaponProficiencies.Crossbow, Is.Zero);
+    }
+
+    [Test]
+    public void ResetRatingTest()
+    {
+        Character character = new()
+        {
+            Rating = new CharacterRating
+            {
+                Value = 1,
+                Deviation = 2,
+                Volatility = 3,
+            },
+        };
+
+        CharacterService characterService = new(ExperienceTable, Constants);
+        characterService.ResetRating(character);
+
+        Assert.That(character.Rating.Value, Is.EqualTo(Constants.DefaultRating));
+        Assert.That(character.Rating.Deviation, Is.EqualTo(Constants.DefaultRatingDeviation));
+        Assert.That(character.Rating.Volatility, Is.EqualTo(Constants.DefaultRatingVolatility));
     }
 
     [TestCase(31, 1.00f, 1, 1.03f)]

--- a/test/Application.UTest/Games/GetGameUserCommandTest.cs
+++ b/test/Application.UTest/Games/GetGameUserCommandTest.cs
@@ -58,7 +58,6 @@ public class GetGameUserCommandTest : TestBase
         // Check that default values were set for user and character.
         userServiceMock.Verify(us => us.SetDefaultValuesForUser(It.IsAny<User>()));
         characterServiceMock.Verify(cs => cs.SetDefaultValuesForCharacter(It.IsAny<Character>()));
-        characterServiceMock.Verify(cs => cs.ResetCharacterCharacteristics(It.IsAny<Character>(), false));
 
         // Check that user and its owned entities were created
         var dbUser = await AssertDb.Users
@@ -112,7 +111,6 @@ public class GetGameUserCommandTest : TestBase
         // Check that default values were set for character.
         userServiceMock.Verify(us => us.SetDefaultValuesForUser(It.IsAny<User>()), Times.Never);
         characterServiceMock.Verify(cs => cs.SetDefaultValuesForCharacter(It.IsAny<Character>()));
-        characterServiceMock.Verify(cs => cs.ResetCharacterCharacteristics(It.IsAny<Character>(), false));
 
         // Check that user and its owned entities were created
         var dbUser = await AssertDb.Users


### PR DESCRIPTION
Now that respec are not free we can consider resetting rating on respec/retire since changing class can completely change what you are worth.