### PR TITLE
mod: adjust conquest rewards to be fair for both teams

### DIFF
--- a/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
+++ b/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
@@ -54,6 +54,8 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
             return;
         }
 
+        // if oldTeam is null then that means that the player just joined and was added to the attackers
+        // this gives a 3x RewardMultiplier to the player to give more fair rewards compared to the defenders
         if (oldTeam == null && newTeam.Side == BattleSideEnum.Attacker)
         {
             crpgPeer.RewardMultiplier = Math.Max(crpgPeer.RewardMultiplier, 3);

--- a/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
+++ b/src/Module.Server/Modes/Conquest/CrpgConquestServer.cs
@@ -25,6 +25,7 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
     private MissionTimer _flagTickTimer = default!;
     private MissionTimer _currentStageTimer = default!;
     private MissionTimer? _rewardTickTimer;
+    private bool _isOddRewardTick;
 
     public CrpgConquestServer(
         MissionScoreboardComponent missionScoreboardComponent,
@@ -44,6 +45,20 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
     public override bool UseRoundController() => false;
 
     public MBReadOnlyList<FlagCapturePoint> AllCapturePoints { get; private set; } = new(new List<FlagCapturePoint>());
+
+    public override void OnPeerChangedTeam(NetworkCommunicator peer, Team oldTeam, Team newTeam)
+    {
+        var crpgPeer = peer.GetComponent<CrpgPeer>();
+        if (crpgPeer?.User == null)
+        {
+            return;
+        }
+
+        if (oldTeam == null && newTeam.Side == BattleSideEnum.Attacker)
+        {
+            crpgPeer.RewardMultiplier = Math.Max(crpgPeer.RewardMultiplier, 3);
+        }
+    }
 
     public override void OnBehaviorInitialize()
     {
@@ -65,6 +80,7 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
 
         if (!_gameStarted)
         {
+            _isOddRewardTick = true;
             StartStage(0);
             _gameStarted = true;
         }
@@ -371,6 +387,7 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
             durationRewarded: _rewardTickTimer!.GetRemainingTimeInSeconds(),
             defenderMultiplierGain: -CrpgRewardServer.ExperienceMultiplierMax,
             attackerMultiplierGain: CrpgRewardServer.ExperienceMultiplierMax);
+        _isOddRewardTick = true;
 
         StartStage(_currentStage);
     }
@@ -417,10 +434,25 @@ internal class CrpgConquestServer : MissionMultiplayerGameModeBase, IAnalyticsFl
     {
         if (_rewardTickTimer!.Check(reset: true))
         {
+            int defenderMultiplierGain;
+            int attackerMultiplierGain;
+            if (_isOddRewardTick)
+            {
+                defenderMultiplierGain = 0;
+                attackerMultiplierGain = 0;
+                _isOddRewardTick = false;
+            }
+            else
+            {
+                defenderMultiplierGain = 1;
+                attackerMultiplierGain = -1;
+                _isOddRewardTick = true;
+            }
+
             _ = _rewardServer.UpdateCrpgUsersAsync(
                 durationRewarded: _rewardTickTimer.GetTimerDuration(),
-                defenderMultiplierGain: 1,
-                attackerMultiplierGain: -1);
+                defenderMultiplierGain,
+                attackerMultiplierGain);
         }
     }
 

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -135,7 +135,7 @@ internal class CrpgRewardServer : MissionLogic
             return;
         }
 
-        bool lowPopulationServer = networkPeers.Length < 4;
+        bool lowPopulationServer = false;
 
         // Force constant multiplier if there is low population.
         constantMultiplier = lowPopulationServer ? ExperienceMultiplierMin : constantMultiplier;

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -135,7 +135,7 @@ internal class CrpgRewardServer : MissionLogic
             return;
         }
 
-        bool lowPopulationServer = false;
+        bool lowPopulationServer = networkPeers.Length < 4;
 
         // Force constant multiplier if there is low population.
         constantMultiplier = lowPopulationServer ? ExperienceMultiplierMin : constantMultiplier;


### PR DESCRIPTION
As people many times saids that conquest doesn't give fair rewards to attackers i adjusted the behaviour of the multiplier as shown in this concept:
https://docs.google.com/spreadsheets/d/1IzlttmcPsHRfWwRVzOeCJ9wGHe7ghe3ZvzbN54MLecY/edit#gid=1602412326

Please note that the tick rate is supposed to be 30seconds. So that needs to be adjusted aswell after patching.