### PR TITLE
mod: fix valour in first round after warmup

### DIFF
--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -141,7 +141,9 @@ internal class CrpgRewardServer : MissionLogic
         constantMultiplier = lowPopulationServer ? ExperienceMultiplierMin : constantMultiplier;
 
         CrpgRatingCalculator.UpdateRatings(_ratingResults);
-        Dictionary<PlayerId, PeriodStats> periodStats = _periodStatsHelper.ComputePeriodStats();
+        Dictionary<PlayerId, PeriodStats> periodStats = updateUserStats
+            ? _periodStatsHelper.ComputePeriodStats()
+            : new();
 
         var valorousPlayerIds = lowPopulationServer || !valourTeamSide.HasValue
             ? new HashSet<PlayerId>()


### PR DESCRIPTION
The periodStats (stats from scoreboard) were also calculated for the warmup, so the delta of the last round (warmup) and the first round were scewed, because people don't play seriously in warmup.

Related Issue: https://github.com/verdie-g/crpg/issues/943