### PR TITLE
webUI: Update Skill Descriptions for Increased Clarity

### DIFF
--- a/src/WebUI/locales/en.yml
+++ b/src/WebUI/locales/en.yml
@@ -348,19 +348,19 @@ character:
       children:
         ironFlesh:
           title: Iron flesh
-          desc: Increases your health
+          desc: Increases your health by +4
           requires: '@:character.characteristic.requires.linked.threeStr'
         powerStrike:
           title: Power strike
-          desc: Increases melee damage
+          desc: Increases melee weapon damage by +8%
           requires: '@:character.characteristic.requires.linked.threeStr'
         powerDraw:
           title: Power draw
-          desc: Increases bow damage
+          desc: Increases bow damage by +14%
           requires: '@:character.characteristic.requires.linked.threeStr'
         powerThrow:
           title: Power throw
-          desc: Increases throw damage
+          desc: Increases throwing weapon damage by +10%
           requires: '@:character.characteristic.requires.linked.threeStr'
         athletics:
           title: Athletics
@@ -372,7 +372,7 @@ character:
           requires: '@:character.characteristic.requires.linked.threeAgi'
         weaponMaster:
           title: Weapon master
-          desc: Gives weapon points
+          desc: Gives weapon proficiency points
           requires: '@:character.characteristic.requires.linked.threeAgi'
         mountedArchery:
           title: Mounted archery
@@ -380,7 +380,7 @@ character:
           requires: '@:character.characteristic.requires.linked.sixAgi'
         shield:
           title: Shield
-          desc: Improves shield durability. Increases coverage from ranged attacks
+          desc: Improves shield durability. Increases coverage from ranged attacks. Reduces stun from weapons when hit
           requires: '@:character.characteristic.requires.linked.sixAgi'
 
     weaponProficiencies:


### PR DESCRIPTION
This commit enhances the descriptions of several skills in the game to provide players with more specific information regarding skill effects. The updated skills and their changes are as follows:

1) Updated description for Iron Flesh to give the value it increases by (+4)

2) Updated description for Power Strike to give the value it increases by (+8%)

3) Updated description for Power Draw to give the value it increases by (+14%)

4) Updated description for Power Throw to give the value it increase by (+10%)

5) Updated description for Shield to add that it reduces stun from weapons when hit

_(all values calculated as follows:
0.08 * 100 = 8%
0.14 * 100 = 14%
0.10 * 100 = 10%
from:
"damageFactorForPowerStrikeCoefs": [0.08, 1.0],
"damageFactorForPowerDrawCoefs": [0.14, 1.0],
"damageFactorForPowerThrowCoefs": [0.10, 1.0], )_

By being more explicit about each skill's impact, we can enhance the player's understanding of game mechanics and promote informed decision-making during skill selection.