### PR TITLE
mod: only enable rating in battle

### DIFF
--- a/src/Module.Server/Modes/Battle/CrpgBattleGameMode.cs
+++ b/src/Module.Server/Modes/Battle/CrpgBattleGameMode.cs
@@ -98,7 +98,7 @@ internal class CrpgBattleGameMode : MissionBasedMultiplayerGameMode
                 ? new CrpgSkirmishSpawningBehavior(_constants, roundController)
                 : new CrpgBattleSpawningBehavior(_constants, roundController)));
         CrpgTeamSelectComponent teamSelectComponent = new(warmupComponent, roundController);
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: true);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: true, enableRating: true);
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent, null);
         CrpgTeamSelectComponent teamSelectComponent = new();

--- a/src/Module.Server/Modes/Conquest/CrpgConquestGameMode.cs
+++ b/src/Module.Server/Modes/Conquest/CrpgConquestGameMode.cs
@@ -79,7 +79,7 @@ internal class CrpgConquestGameMode : MissionBasedMultiplayerGameMode
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent,
             () => (new SiegeSpawnFrameBehavior(), new CrpgSiegeSpawningBehavior(_constants)));
         CrpgTeamSelectComponent teamSelectComponent = new(warmupComponent, null);
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: false);
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent, null);
         CrpgTeamSelectComponent teamSelectComponent = new();

--- a/src/Module.Server/Modes/Duel/CrpgDuelGameMode.cs
+++ b/src/Module.Server/Modes/Duel/CrpgDuelGameMode.cs
@@ -71,7 +71,7 @@ internal class CrpgDuelGameMode : MissionBasedMultiplayerGameMode
 #if CRPG_SERVER
         ICrpgClient crpgClient = CrpgClient.Create();
         ChatBox chatBox = Game.Current.GetGameHandler<ChatBox>();
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, null, enableTeamHitCompensations: false);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, null, enableTeamHitCompensations: false, enableRating: false);
         CrpgDuelServer duelServer = new(rewardServer);
 #endif
         CrpgDuelMissionMultiplayerClient duelClient = new();

--- a/src/Module.Server/Modes/Siege/CrpgSiegeGameMode.cs
+++ b/src/Module.Server/Modes/Siege/CrpgSiegeGameMode.cs
@@ -78,7 +78,7 @@ internal class CrpgSiegeGameMode : MissionBasedMultiplayerGameMode
         ChatBox chatBox = Game.Current.GetGameHandler<ChatBox>();
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent,
             () => (new SiegeSpawnFrameBehavior(), new CrpgSiegeSpawningBehavior(_constants)));
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: false);
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent, null);
 #endif

--- a/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
+++ b/src/Module.Server/Modes/TeamDeathmatch/CrpgTeamDeathmatchGameMode.cs
@@ -77,7 +77,7 @@ internal class CrpgTeamDeathmatchGameMode : MissionBasedMultiplayerGameMode
         ChatBox chatBox = Game.Current.GetGameHandler<ChatBox>();
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent,
             () => (new TeamDeathmatchSpawnFrameBehavior(), new CrpgTeamDeathmatchSpawningBehavior(_constants)));
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: false);
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent, null);
 #endif

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -124,7 +124,7 @@ internal class CrpgRewardServer : MissionLogic
     /// <param name="attackerMultiplierGain">Multiplier to add to the attackers. Can be negative.</param>
     /// <param name="valourTeamSide">Team to give valour to.</param>
     /// <param name="constantMultiplier">Multiplier that should be given to everyone disregarding any other parameters.</param>
-    /// <param name="updateUserStats">True if stats (e.g. KDA) should be saved.</param>
+    /// <param name="updateUserStats">True if score and rating should be saved.</param>
     public async Task UpdateCrpgUsersAsync(
         float durationRewarded,
         int defenderMultiplierGain = 0,
@@ -188,7 +188,7 @@ internal class CrpgRewardServer : MissionLogic
                 continue;
             }
 
-            if (_isRatingEnabled)
+            if (_isRatingEnabled && updateUserStats)
             {
                 userUpdate.Rating = GetNewRating(crpgPeer);
             }

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -124,7 +124,7 @@ internal class CrpgRewardServer : MissionLogic
     /// <param name="attackerMultiplierGain">Multiplier to add to the attackers. Can be negative.</param>
     /// <param name="valourTeamSide">Team to give valour to.</param>
     /// <param name="constantMultiplier">Multiplier that should be given to everyone disregarding any other parameters.</param>
-    /// <param name="updateUserStats">True if score and rating should be saved.</param>
+    /// <param name="updateUserStats">True if stats (e.g. KDA) should be saved.</param>
     public async Task UpdateCrpgUsersAsync(
         float durationRewarded,
         int defenderMultiplierGain = 0,

--- a/src/Module.Server/Rewards/CrpgRewardServer.cs
+++ b/src/Module.Server/Rewards/CrpgRewardServer.cs
@@ -31,6 +31,7 @@ internal class CrpgRewardServer : MissionLogic
     private readonly PeriodStatsHelper _periodStatsHelper;
     private readonly Dictionary<int, AgentHitRegistry> _agentsThatGotTeamHitThisRoundByCrpgUserId;
     private readonly bool _isTeamHitCompensationsEnabled;
+    private readonly bool _isRatingEnabled;
 
     private bool _lastRewardDuringHappyHours;
 
@@ -38,7 +39,8 @@ internal class CrpgRewardServer : MissionLogic
         ICrpgClient crpgClient,
         CrpgConstants constants,
         CrpgWarmupComponent? warmupComponent,
-        bool enableTeamHitCompensations)
+        bool enableTeamHitCompensations,
+        bool enableRating)
     {
         _crpgClient = crpgClient;
         _constants = constants;
@@ -50,6 +52,7 @@ internal class CrpgRewardServer : MissionLogic
         _lastRewardDuringHappyHours = false;
         _agentsThatGotTeamHitThisRoundByCrpgUserId = new();
         _isTeamHitCompensationsEnabled = enableTeamHitCompensations;
+        _isRatingEnabled = enableRating;
     }
 
     public override MissionBehaviorType BehaviorType => MissionBehaviorType.Other;
@@ -102,7 +105,8 @@ internal class CrpgRewardServer : MissionLogic
             return;
         }
 
-        if (!TryGetRating(affectedAgent, out var affectedRating)
+        if (!_isRatingEnabled
+            || !TryGetRating(affectedAgent, out var affectedRating)
             || !TryGetRating(affectorAgent, out var affectorRating))
         {
             return;
@@ -184,7 +188,7 @@ internal class CrpgRewardServer : MissionLogic
                 continue;
             }
 
-            if (updateUserStats)
+            if (_isRatingEnabled)
             {
                 userUpdate.Rating = GetNewRating(crpgPeer);
             }


### PR DESCRIPTION
Conquest can be a cluster fuck and rating gains/loses are not very relevant so I suggest to disable it. Rating will still be used for team balancing though.