### PR TITLE
webui: disabled router stringify encode

### DIFF
--- a/src/WebUI/src/utils/router.ts
+++ b/src/WebUI/src/utils/router.ts
@@ -45,6 +45,7 @@ export const stringifyQuery = (query: Record<string, any>) =>
     strictNullHandling: true,
     arrayFormat: 'brackets',
     skipNulls: true,
+    encode: false,
   });
 
 export const scrollBehavior: RouterScrollBehavior = (to, _from, savedPosition) => {


### PR DESCRIPTION
This edit also affects `shop` page and others where there are query params. 
Tested it, nothing seems to be broken