### PR TITLE
webui: hotfix isNew item filter

### DIFF
--- a/src/WebUI/src/assets/themes/oruga-tailwind/components/checkbox.css
+++ b/src/WebUI/src/assets/themes/oruga-tailwind/components/checkbox.css
@@ -25,3 +25,7 @@
 .o-chk--checked .o-chk__label {
   @apply text-content-100 hover:text-content-300;
 }
+
+.o-chk--disabled {
+  @apply pointer-events-none opacity-50;
+}

--- a/src/WebUI/src/pages/shop.vue
+++ b/src/WebUI/src/pages/shop.vue
@@ -92,6 +92,10 @@ const buyItem = async (item: ItemFlat) => {
 };
 
 const isUpgradableCategory = computed(() => canUpgrade(itemTypeModel.value));
+
+const newItemCount = computed(
+  () => searchResult.value.data.aggregations.new.buckets.find(b => b.key === '1')?.doc_count ?? 0
+);
 </script>
 
 <template>
@@ -133,10 +137,12 @@ const isUpgradableCategory = computed(() => canUpgrade(itemTypeModel.value));
               <OCheckbox
                 :nativeValue="1"
                 :modelValue="filterModel['new']"
+                :disabled="newItemCount === 0"
                 @update:modelValue="(val: number) => updateFilter('new', val)"
                 @change="hide"
               >
                 {{ $t('item.aggregations.new.title') }}
+                ({{ newItemCount }})
               </OCheckbox>
             </Tooltip>
           </DropdownItem>


### PR DESCRIPTION
Made the checkbox disabled if there are no new items in a category, otherwise the itemsjs library gives an error
https://github.com/itemsapi/itemsjs/issues/128
https://github.com/itemsapi/itemsjs/issues/102