### PR TITLE
mod: increase dtv map time limit

### DIFF
--- a/src/Module.Server/ds_config_crpg_dtv.txt
+++ b/src/Module.Server/ds_config_crpg_dtv.txt
@@ -9,7 +9,7 @@ disable_culture_voting
 CultureTeam1 vlandia
 CultureTeam2 battania
 RoundPreparationTimeLimit 2
-MapTimeLimit 60
+MapTimeLimit 150
 MaxNumberOfPlayers 32
 AutoTeamBalanceThreshold 5
 FriendlyFireDamageMeleeFriendPercent 50


### PR DESCRIPTION
increase dtv map time limit to 2.5 hours (currently there's not enough time to complete all rounds)