### PR TITLE
mod: disable teamhit compensation in DTV gamemode

### DIFF
--- a/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvGameMode.cs
@@ -86,7 +86,7 @@ internal class CrpgDtvGameMode : MissionBasedMultiplayerGameMode
             (new FlagDominationSpawnFrameBehavior(),
             new CrpgDtvSpawningBehavior(_constants)));
         CrpgTeamSelectServerComponent teamSelectComponent = new(warmupComponent, null);
-        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: true, enableRating: false);
+        CrpgRewardServer rewardServer = new(crpgClient, _constants, warmupComponent, enableTeamHitCompensations: false, enableRating: false);
         CrpgDtvSpawningBehavior spawnBehaviour = new(_constants);
 #else
         CrpgWarmupComponent warmupComponent = new(_constants, notificationsComponent, null);


### PR DESCRIPTION
i don't cap the values because the calculation is actually done after every reward tick, aka every round end on battle.
But on DTV you get healed every wave, so you effectively have 300% health until the reward tick.

This would lead to transferring gold 200% of the upkeep from player to player