### PR TITLE
mod: fix dtv messages in warmup

### DIFF
--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -129,13 +129,14 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         float hitDistance,
         float shotDifficulty)
     {
-        if (_gameStarted)
+        if (!_gameStarted)
         {
-            if (affectedAgent.IsAIControlled && affectedAgent.Team == Mission.DefenderTeam) // Viscount under attack
-            {
-                SendDataToPeers(new CrpgDtvViscountUnderAttackMessage { Attacker = affectorAgent });
-                return;
-            }
+            return;
+        }
+
+        if (affectedAgent.IsAIControlled && affectedAgent.Team == Mission.DefenderTeam) // Viscount under attack
+        {
+            SendDataToPeers(new CrpgDtvViscountUnderAttackMessage { Attacker = affectorAgent });
         }
     }
 

--- a/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
+++ b/src/Module.Server/Modes/Dtv/CrpgDtvServer.cs
@@ -129,10 +129,13 @@ internal class CrpgDtvServer : MissionMultiplayerGameModeBase
         float hitDistance,
         float shotDifficulty)
     {
-        if (affectedAgent.IsAIControlled && affectedAgent.Team == Mission.DefenderTeam) // Viscount under attack
+        if (_gameStarted)
         {
-            SendDataToPeers(new CrpgDtvViscountUnderAttackMessage { Attacker = affectorAgent });
-            return;
+            if (affectedAgent.IsAIControlled && affectedAgent.Team == Mission.DefenderTeam) // Viscount under attack
+            {
+                SendDataToPeers(new CrpgDtvViscountUnderAttackMessage { Attacker = affectorAgent });
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
Viscount under attack messages were firing during warmup when a bot was hit on the defending team.

Fix for #1218 